### PR TITLE
Add Windows subtitle TTS support

### DIFF
--- a/src/MpvNet.Windows/Config.cs
+++ b/src/MpvNet.Windows/Config.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+
+namespace MpvNet.Windows;
+
+static class Config
+{
+    static readonly string ConfigPath = Player.ConfigFolder + "Config.json";
+    static Dictionary<string, JsonElement> _values = new();
+
+    public static void Load()
+    {
+        try
+        {
+            if (File.Exists(ConfigPath))
+                _values = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(File.ReadAllText(ConfigPath)) ?? new();
+        }
+        catch { _values = new(); }
+    }
+
+    public static void Save()
+    {
+        try
+        {
+            File.WriteAllText(ConfigPath, JsonSerializer.Serialize(_values, new JsonSerializerOptions { WriteIndented = true }));
+        }
+        catch { }
+    }
+
+    public static bool GetBool(string name)
+    {
+        if (_values.TryGetValue(name, out var el) && (el.ValueKind == JsonValueKind.True || el.ValueKind == JsonValueKind.False))
+            return el.GetBoolean();
+        return false;
+    }
+
+    public static string GetString(string name)
+    {
+        if (_values.TryGetValue(name, out var el) && el.ValueKind == JsonValueKind.String)
+            return el.GetString() ?? "";
+        return "";
+    }
+
+    public static void SetBool(string name, bool value)
+    {
+        _values[name] = JsonDocument.Parse(value ? "true" : "false").RootElement.Clone();
+    }
+
+    public static void SetString(string name, string value)
+    {
+        _values[name] = JsonDocument.Parse(JsonSerializer.Serialize(value)).RootElement.Clone();
+    }
+}

--- a/src/MpvNet.Windows/GuiCommand.cs
+++ b/src/MpvNet.Windows/GuiCommand.cs
@@ -43,6 +43,7 @@ public class GuiCommand
         ["remove-from-path"] = args => RemoveFromPath(),
         ["scale-window"] = args => ScaleWindow?.Invoke(float.Parse(args[0], CultureInfo.InvariantCulture)),
         ["show-about"] = args => ShowDialog(typeof(AboutWindow)),
+        ["show-settings"] = args => ShowDialog(typeof(SettingsDialog)),
         ["show-bindings"] = args => ShowBindings(),
         ["show-commands"] = args => ShowCommands(),
         ["show-conf-editor"] = args => ShowDialog(typeof(ConfWindow)),

--- a/src/MpvNet.Windows/MpvNet.Windows.csproj
+++ b/src/MpvNet.Windows/MpvNet.Windows.csproj
@@ -39,9 +39,10 @@
 		</Page>
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" />
-		<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="CommunityToolkit.Mvvm" />
+                <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
+                <Reference Include="System.Speech" />
+        </ItemGroup>
 
 </Project>

--- a/src/MpvNet.Windows/Program.cs
+++ b/src/MpvNet.Windows/Program.cs
@@ -39,6 +39,9 @@ static class Program
 
             App.Init();
             Theme.Init();
+            Config.Load();
+            TTSConfig.Load();
+            TTSManager.Init();
             Mutex mutex = new Mutex(true, StringHelp.GetMD5Hash(App.ConfPath), out bool isFirst);
 
             if (Control.ModifierKeys == Keys.Shift ||

--- a/src/MpvNet.Windows/TTSConfig.cs
+++ b/src/MpvNet.Windows/TTSConfig.cs
@@ -1,0 +1,19 @@
+namespace MpvNet.Windows;
+
+public static class TTSConfig
+{
+    public static bool EnableTTS = false;
+    public static string SelectedVoice = "";
+
+    public static void Load()
+    {
+        EnableTTS = Config.GetBool("EnableTTS");
+        SelectedVoice = Config.GetString("TTSVoice");
+    }
+
+    public static void Save()
+    {
+        Config.SetBool("EnableTTS", EnableTTS);
+        Config.SetString("TTSVoice", SelectedVoice);
+    }
+}

--- a/src/MpvNet.Windows/TTSManager.cs
+++ b/src/MpvNet.Windows/TTSManager.cs
@@ -1,0 +1,35 @@
+using System.Speech.Synthesis;
+
+namespace MpvNet.Windows;
+
+public static class TTSManager
+{
+    static SpeechSynthesizer synth = new SpeechSynthesizer();
+    static string last = "";
+
+    public static void Init()
+    {
+        if (!string.IsNullOrEmpty(TTSConfig.SelectedVoice))
+        {
+            try { synth.SelectVoice(TTSConfig.SelectedVoice); } catch { }
+        }
+    }
+
+    public static void Speak(string text)
+    {
+        if (TTSConfig.EnableTTS && !string.IsNullOrWhiteSpace(text) && text != last)
+        {
+            last = text;
+            synth.SpeakAsyncCancelAll();
+            synth.SpeakAsync(text);
+        }
+    }
+
+    public static string[] GetInstalledVoices()
+    {
+        List<string> voices = new List<string>();
+        foreach (var v in synth.GetInstalledVoices())
+            voices.Add(v.VoiceInfo.Name);
+        return voices.ToArray();
+    }
+}

--- a/src/MpvNet.Windows/WPF/SettingsDialog.xaml
+++ b/src/MpvNet.Windows/WPF/SettingsDialog.xaml
@@ -1,0 +1,21 @@
+<Window x:Class="MpvNet.Windows.WPF.SettingsDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings" Height="160" Width="300"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        ResizeMode="NoResize"
+        Foreground="{Binding Theme.Foreground}"
+        Background="{Binding Theme.Background}">
+    <StackPanel Margin="10">
+        <CheckBox Content="Enable Subtitle TTS" IsChecked="{Binding EnableTTS}" Margin="0,0,0,10"/>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+            <TextBlock Text="Select Voice" VerticalAlignment="Center" Margin="0,0,5,0"/>
+            <ComboBox Width="200" ItemsSource="{Binding Voices}" SelectedItem="{Binding SelectedVoice}"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Content="OK" Width="75" Margin="0,0,5,0" IsDefault="True" Click="OK_Click"/>
+            <Button Content="Cancel" Width="75" IsCancel="True"/>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/src/MpvNet.Windows/WPF/SettingsDialog.xaml.cs
+++ b/src/MpvNet.Windows/WPF/SettingsDialog.xaml.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using System.Windows;
+
+namespace MpvNet.Windows.WPF;
+
+public partial class SettingsDialog : Window
+{
+    public string[] Voices { get; }
+    public bool EnableTTS { get; set; }
+    public string SelectedVoice { get; set; }
+
+    public SettingsDialog()
+    {
+        InitializeComponent();
+        Voices = TTSManager.GetInstalledVoices();
+        EnableTTS = TTSConfig.EnableTTS;
+        SelectedVoice = string.IsNullOrEmpty(TTSConfig.SelectedVoice) ? Voices.FirstOrDefault() ?? "" : TTSConfig.SelectedVoice;
+        DataContext = this;
+    }
+
+    void OK_Click(object sender, RoutedEventArgs e)
+    {
+        TTSConfig.EnableTTS = EnableTTS;
+        if (!string.IsNullOrEmpty(SelectedVoice))
+            TTSConfig.SelectedVoice = SelectedVoice;
+        TTSManager.Init();
+        DialogResult = true;
+        Close();
+    }
+
+    public Theme? Theme => Theme.Current;
+}

--- a/src/MpvNet.Windows/WinForms/MainForm.cs
+++ b/src/MpvNet.Windows/WinForms/MainForm.cs
@@ -85,6 +85,7 @@ public partial class MainForm : Form
             Player.ObservePropertyString("vid", PropChangeVid);
 
             Player.ObservePropertyString("title", PropChangeTitle);
+            Player.ObservePropertyString("sub-text", text => TTSManager.Speak(text));
 
             Player.ObservePropertyInt("edition", PropChangeEdition);
 
@@ -1424,6 +1425,9 @@ public partial class MainForm : Form
     protected override void OnFormClosing(FormClosingEventArgs e)
     {
         base.OnFormClosing(e);
+
+        TTSConfig.Save();
+        Config.Save();
 
         if (Player.IsQuitNeeded)
             Player.CommandV("quit");

--- a/src/MpvNet/InputHelp.cs
+++ b/src/MpvNet/InputHelp.cs
@@ -229,6 +229,7 @@ public static class InputHelp
         Add(b, new (_("Tools"), _("Shuffle Playlist"), "playlist-shuffle"));
         Add(b, new (_("Tools"), _("Toggle Hardware Decoding"), "cycle-values hwdec auto no", "Ctrl+h"));
         Add(b, new (_("Tools"), _("Exit Watch Later"), "quit-watch-later", "Q"));
+        Add(b, new (_("Tools"), "Subtitle TTS Settings", "script-message-to mpvnet show-settings"));
 
         Add(b, new ("", _("Custom")));
 


### PR DESCRIPTION
## Summary
- introduce Config system and TTS configuration
- implement TTSManager using `System.Speech`
- provide a simple Settings dialog for selecting voice and enabling TTS
- hook subtitle text property and speak it asynchronously
- expose new command `show-settings`
- persist settings on exit

## Testing
- `dotnet build src/MpvNet.sln -c Release` *(fails: NETSDK1045, .NET 9 SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848cb56d6cc8331a0d2d19e800a426f